### PR TITLE
feat: capture quest context for AI planning

### DIFF
--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -33,8 +33,42 @@ async function completeQuest() {
             {{ quest.title }}
           </v-card-title>
           <v-card-subtitle>Status: <strong>{{ quest.status }}</strong></v-card-subtitle>
-          <v-card-text>
-            <p>{{ quest.description }}</p>
+          <v-card-text class="d-flex flex-column gap-4">
+            <div>
+              <h3 class="text-subtitle-1 font-weight-medium mb-1">
+                Quest Description
+              </h3>
+              <p class="mb-0">
+                {{ quest.description || 'No description provided.' }}
+              </p>
+            </div>
+
+            <div v-if="quest.goal">
+              <h3 class="text-subtitle-1 font-weight-medium mb-1">
+                Desired Outcome
+              </h3>
+              <p class="mb-0">
+                {{ quest.goal }}
+              </p>
+            </div>
+
+            <div v-if="quest.context">
+              <h3 class="text-subtitle-1 font-weight-medium mb-1">
+                Context
+              </h3>
+              <p class="mb-0">
+                {{ quest.context }}
+              </p>
+            </div>
+
+            <div v-if="quest.constraints">
+              <h3 class="text-subtitle-1 font-weight-medium mb-1">
+                Constraints & Preferences
+              </h3>
+              <p class="mb-0">
+                {{ quest.constraints }}
+              </p>
+            </div>
           </v-card-text>
 
           <v-divider class="my-4" />

--- a/apps/nuxt/pages/quests/index.vue
+++ b/apps/nuxt/pages/quests/index.vue
@@ -35,8 +35,16 @@ const { data: quests } = await useQuests()
       >
         <v-card>
           <v-card-title>{{ quest.title }}</v-card-title>
-          <v-card-text>
-            <p>{{ quest.description }}</p>
+          <v-card-text class="d-flex flex-column gap-2">
+            <p class="mb-0">
+              {{ quest.description }}
+            </p>
+            <p
+              v-if="quest.goal"
+              class="text-body-2 text-medium-emphasis mb-0"
+            >
+              <strong>Goal:</strong> {{ quest.goal }}
+            </p>
           </v-card-text>
           <v-card-actions>
             <v-btn :to="`/quests/${quest.id}`">

--- a/apps/nuxt/pages/quests/new.vue
+++ b/apps/nuxt/pages/quests/new.vue
@@ -6,7 +6,9 @@ import { useRouter } from 'vue-router'
 const router = useRouter()
 const title = ref('')
 const description = ref('')
-const userId = ref('')
+const goal = ref('')
+const context = ref('')
+const constraints = ref('')
 
 const valid = ref(false)
 const loading = ref(false)
@@ -22,7 +24,9 @@ async function submit() {
       body: {
         title: title.value,
         description: description.value,
-        userId: userId.value,
+        goal: goal.value,
+        context: context.value,
+        constraints: constraints.value,
       },
     })
 
@@ -83,6 +87,33 @@ async function submit() {
               label="Description"
               :rules="[v => !!v || 'Description is required']"
               required
+              auto-grow
+              rows="3"
+            />
+
+            <v-textarea
+              v-model="goal"
+              label="What outcome are you aiming for?"
+              hint="Share the specific result you want this quest to achieve."
+              persistent-hint
+              auto-grow
+              rows="3"
+            />
+
+            <v-textarea
+              v-model="context"
+              label="Relevant background or context"
+              hint="Include any details, prior work, or information that will help the AI understand the situation."
+              persistent-hint
+              auto-grow
+              rows="3"
+            />
+
+            <v-textarea
+              v-model="constraints"
+              label="Constraints or preferences"
+              hint="List deadlines, available resources, tone, or other requirements to respect."
+              persistent-hint
               auto-grow
               rows="3"
             />

--- a/apps/nuxt/server/api/quests/index.post.ts
+++ b/apps/nuxt/server/api/quests/index.post.ts
@@ -6,7 +6,13 @@ const handler = defineEventHandler(async (event) => {
   const { user } = await requireUserSession(event) // 👈 forces login
 
   const body = await readBody(event)
-  const { title, description } = body
+  const {
+    title,
+    description,
+    goal,
+    context,
+    constraints,
+  } = body
 
   // Access the queue from the event context
   // TODO: deretmine potentially better way to access this
@@ -16,11 +22,21 @@ const handler = defineEventHandler(async (event) => {
     data: {
       title,
       description,
+      goal,
+      context,
+      constraints,
       ownerId: user.id,
     },
   })
 
-  await questQueue.add('decompose', { questId: quest.id, title, description })
+  await questQueue.add('decompose', {
+    questId: quest.id,
+    title,
+    description,
+    goal,
+    context,
+    constraints,
+  })
 
   return { success: true, quest }
 })

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -13,10 +13,23 @@ new Worker(
   async (job) => {
     if (job.name === 'decompose') {
       console.log('Decomposing quest:', job.data);
-      const { questId, title, description } = job.data;
+      const { questId, title, description, goal, context, constraints } = job.data;
 
-      const prompt = `Decompose the quest "${title}: ${description}" into ordered sub-tasks. 
-    Return as JSON array of {title, details}.`;
+      const promptSections = [
+        `Quest Title: ${title}`,
+        description ? `Quest Description: ${description}` : null,
+        goal ? `Desired Outcome: ${goal}` : null,
+        context ? `Additional Context: ${context}` : null,
+        constraints ? `Constraints or Preferences: ${constraints}` : null,
+      ].filter((section): section is string => Boolean(section));
+
+      const prompt = `You are an expert project planner. Based on the following quest information, break the work down into a
+    thoughtfully ordered list of actionable sub-tasks. Each task should be specific enough to execute without additional
+    clarification and collectively lead to the desired outcome.
+
+${promptSections.join('\n')}
+
+Return the plan as a JSON array where each item has the shape {"title": string, "details": string}.`;
       console.log('Prompt:', prompt);
       try {
         const response = await openai.chat.completions.create({

--- a/packages/prisma/migrations/20251001120000_add_prompt_fields/migration.sql
+++ b/packages/prisma/migrations/20251001120000_add_prompt_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Quest"
+ADD COLUMN     "goal" TEXT,
+ADD COLUMN     "context" TEXT,
+ADD COLUMN     "constraints" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -22,6 +22,9 @@ model Quest {
   ownerId   String
   title     String
   description String?
+  goal       String?
+  context    String?
+  constraints String?
   status    String   @default("draft") // draft, active, completed
   tasks     Task[]
   createdAt DateTime @default(now())


### PR DESCRIPTION
## Summary
- add goal, context, and constraint fields to the quest schema with a migration
- extend the quest creation flow to collect richer planning inputs and display them in quest pages
- enhance the worker prompt to incorporate the new quest metadata when generating tasks

## Testing
- pnpm --filter nuxt lint
- pnpm --filter worker lint

------
https://chatgpt.com/codex/tasks/task_e_68e47bac7118832887e29466e4075dea