### PR TITLE
Add loading indicator while quest tasks are generated

### DIFF
--- a/apps/nuxt/package.json
+++ b/apps/nuxt/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@prisma/client": "5.22.0",
+    "@vueuse/core": "^13.9.0",
     "bullmq": "^4.0.0",
     "nuxt": "^3.13.0",
     "nuxt-auth-utils": "^0.5.25",

--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -15,11 +15,6 @@ const tasksLoading = computed(() => {
 
   const tasks = currentQuest.tasks ?? []
 
-  console.log('Tasks loading check:', {
-    status: currentQuest.status,
-    tasksCount: tasks.length,
-  })
-
   return currentQuest.status === 'draft' && tasks.length === 0
 })
 
@@ -41,12 +36,11 @@ async function completeQuest() {
 
 onMounted(() => {
   const { pause, resume } = useIntervalFn(() => {
-    console.log('Polling for quest updates...')
     refresh()
   }, 2000, { immediate: false })
 
   watch(tasksLoading, (loading) => {
-    if (loading) resume()
+    if (loading && !pending.value) resume()
     else pause()
   }, { immediate: true })
 })

--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -2,8 +2,6 @@
 import { useIntervalFn } from '@vueuse/core'
 import { useQuest } from '~/composables/useQuest'
 
-const { isClient } = useNuxtApp()
-
 const route = useRoute()
 const id = route.params.id as string
 
@@ -25,20 +23,6 @@ const tasksLoading = computed(() => {
   return currentQuest.status === 'draft' && tasks.length === 0
 })
 
-if (isClient) {
-  // Setup the interval but start it paused
-  const { pause, resume } = useIntervalFn(() => {
-    console.log('Polling for quest updates...')
-    refresh()
-  }, 2000, { immediate: false })
-
-  // Watch for loading state
-  watch(tasksLoading, (loading) => {
-    if (loading) resume()
-    else pause()
-  }, { immediate: true })
-}
-
 async function markTaskCompleted(taskId: string) {
   await $fetch(`/api/tasks/${taskId}`, {
     method: 'PATCH',
@@ -54,6 +38,18 @@ async function completeQuest() {
   })
   await refresh()
 }
+
+onMounted(() => {
+  const { pause, resume } = useIntervalFn(() => {
+    console.log('Polling for quest updates...')
+    refresh()
+  }, 2000, { immediate: false })
+
+  watch(tasksLoading, (loading) => {
+    if (loading) resume()
+    else pause()
+  }, { immediate: true })
+})
 </script>
 
 <template>

--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -20,7 +20,7 @@ const tasksLoading = computed(() => {
 })
 
 if (import.meta.client) {
-  let pollTimer: ReturnType<typeof setInterval> | null = null
+  let pollTimer: number | null = null
 
   watch(
     tasksLoading,

--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -132,6 +132,7 @@ onMounted(() => {
               <v-progress-circular
                 color="primary"
                 indeterminate
+                class="mr-2"
               />
               <span class="text-body-2">Generating tasks for this quest...</span>
             </div>

--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -2,6 +2,8 @@
 import { useIntervalFn } from '@vueuse/core'
 import { useQuest } from '~/composables/useQuest'
 
+const { isClient } = useNuxtApp()
+
 const route = useRoute()
 const id = route.params.id as string
 
@@ -18,7 +20,7 @@ const tasksLoading = computed(() => {
   return currentQuest.status === 'draft' && tasks.length === 0
 })
 
-if (useBrowser()) {
+if (isClient) {
   // Setup the interval but start it paused
   const { pause, resume } = useIntervalFn(refresh, 2000, { immediate: false })
 

--- a/apps/nuxt/pages/quests/[id].vue
+++ b/apps/nuxt/pages/quests/[id].vue
@@ -17,12 +17,20 @@ const tasksLoading = computed(() => {
 
   const tasks = currentQuest.tasks ?? []
 
+  console.log('Tasks loading check:', {
+    status: currentQuest.status,
+    tasksCount: tasks.length,
+  })
+
   return currentQuest.status === 'draft' && tasks.length === 0
 })
 
 if (isClient) {
   // Setup the interval but start it paused
-  const { pause, resume } = useIntervalFn(refresh, 2000, { immediate: false })
+  const { pause, resume } = useIntervalFn(() => {
+    console.log('Polling for quest updates...')
+    refresh()
+  }, 2000, { immediate: false })
 
   // Watch for loading state
   watch(tasksLoading, (loading) => {

--- a/apps/nuxt/pages/quests/new.vue
+++ b/apps/nuxt/pages/quests/new.vue
@@ -35,8 +35,8 @@ async function submit() {
       },
     })
 
-    if (res.success) {
-      router.push('/quests')
+    if (res.success && res.quest?.id) {
+      router.push(`/quests/${res.quest.id}`)
     }
     else {
       error.value = 'Failed to create quest'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@prisma/client':
         specifier: 5.22.0
         version: 5.22.0(prisma@5.22.0)
+      '@vueuse/core':
+        specifier: ^13.9.0
+        version: 13.9.0(vue@3.5.21(typescript@5.9.2))
       bullmq:
         specifier: ^4.0.0
         version: 4.18.3
@@ -1756,6 +1759,9 @@ packages:
     resolution: {integrity: sha512-E454lQ6tp9ftVWdZ8VGZpRcIV4YeqVAcx/uifl3P1GGwscYsxOFdYfgIuKasKO0Fm6Np2JM/L378D3bcRQE9hg==}
     deprecated: This is a stub types definition for vue-router (https://github.com/vuejs/vue-router). ecmarkup provides its own type definitions, so you don\'t need @types/ecmarkup installed!
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -2147,6 +2153,19 @@ packages:
     peerDependencies:
       vue: ^3.0.0
       vuetify: ^3.0.0
+
+  '@vueuse/core@13.9.0':
+    resolution: {integrity: sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@13.9.0':
+    resolution: {integrity: sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==}
+
+  '@vueuse/shared@13.9.0':
+    resolution: {integrity: sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==}
+    peerDependencies:
+      vue: ^3.5.0
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -7544,6 +7563,8 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)':
@@ -7998,7 +8019,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/node@24.6.2)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/node@20.19.17)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8180,6 +8201,19 @@ snapshots:
       upath: 2.0.1
       vue: 3.5.21(typescript@5.9.2)
       vuetify: 3.10.3(typescript@5.9.2)(vite-plugin-vuetify@2.1.2)(vue@3.5.21(typescript@5.9.2))
+
+  '@vueuse/core@13.9.0(vue@3.5.21(typescript@5.9.2))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 13.9.0
+      '@vueuse/shared': 13.9.0(vue@3.5.21(typescript@5.9.2))
+      vue: 3.5.21(typescript@5.9.2)
+
+  '@vueuse/metadata@13.9.0': {}
+
+  '@vueuse/shared@13.9.0(vue@3.5.21(typescript@5.9.2))':
+    dependencies:
+      vue: 3.5.21(typescript@5.9.2)
 
   abbrev@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- start client-side polling on the quest detail page to refresh until generated tasks are available
- show a loading indicator and fallback message for tasks while the quest is still being processed

## Testing
- pnpm --filter nuxt lint

------
https://chatgpt.com/codex/tasks/task_e_68e5ae28a16c8328a748cd9f6d906e63