### PR TITLE
test: cover auth and quest pages

### DIFF
--- a/apps/nuxt/tests/components/TextWithLinks.test.ts
+++ b/apps/nuxt/tests/components/TextWithLinks.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TextWithLinks from '~/components/TextWithLinks.vue'
+
+const sampleText = 'Check the docs at https://nuxt.com and follow updates on https://www.example.com/news'
+
+describe('TextWithLinks component', () => {
+  it('renders links with summarized hostnames', async () => {
+    const wrapper = await mountSuspended(TextWithLinks, {
+      props: {
+        text: sampleText,
+      },
+    })
+
+    const anchors = wrapper.findAll('a')
+    expect(anchors).toHaveLength(2)
+    expect(anchors[0]?.attributes('href')).toBe('https://nuxt.com')
+    expect(anchors[0]?.text()).toBe('nuxt.com')
+    expect(anchors[1]?.attributes('href')).toBe('https://www.example.com/news')
+    expect(anchors[1]?.text()).toBe('example.com')
+  })
+
+  it('falls back to the provided message when no text is supplied', async () => {
+    const wrapper = await mountSuspended(TextWithLinks, {
+      props: {
+        fallback: 'Nothing to show',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Nothing to show')
+    expect(wrapper.findAll('a')).toHaveLength(0)
+  })
+})

--- a/apps/nuxt/tests/composables/useQuest.test.ts
+++ b/apps/nuxt/tests/composables/useQuest.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+let useFetchMock: ReturnType<typeof vi.fn>
+const restoreUseFetch = mockNuxtImport('useFetch', () => (...args: unknown[]) => useFetchMock(...args))
+
+describe('useQuest composables', () => {
+  beforeEach(() => {
+    useFetchMock = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('requests a specific quest with a stable key', async () => {
+    const expected = { data: 'quest-data' }
+    useFetchMock.mockReturnValue(expected)
+
+    const { useQuest } = await import('~/composables/useQuest')
+
+    const result = useQuest('123')
+
+    expect(useFetchMock).toHaveBeenCalledWith('/api/quests/123', { key: 'quest-123' })
+    expect(result).toBe(expected)
+  })
+
+  it('requests the list of quests', async () => {
+    const expected = { data: 'quests-data' }
+    useFetchMock.mockReturnValue(expected)
+
+    const { useQuests } = await import('~/composables/useQuest')
+
+    const result = useQuests()
+
+    expect(useFetchMock).toHaveBeenCalledWith('/api/quests')
+    expect(result).toBe(expected)
+  })
+})
+
+afterAll(() => {
+  restoreUseFetch()
+})

--- a/apps/nuxt/tests/pages/auth/login.test.ts
+++ b/apps/nuxt/tests/pages/auth/login.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { defineAsyncComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const refreshSessionMock = vi.fn()
+const routerPushMock = vi.fn()
+const useUserSessionMock = vi.fn()
+const useRouterMock = vi.fn()
+
+const restoreUserSession = mockNuxtImport('useUserSession', () => useUserSessionMock)
+const restoreUseRouter = mockNuxtImport('useRouter', () => useRouterMock)
+
+describe('Auth login page', () => {
+  beforeEach(() => {
+    refreshSessionMock.mockReset()
+    routerPushMock.mockReset()
+    useUserSessionMock.mockReset()
+    useRouterMock.mockReset()
+
+    useUserSessionMock.mockReturnValue({ fetch: refreshSessionMock })
+    useRouterMock.mockReturnValue({ push: routerPushMock })
+
+    const fetchMock = vi.fn().mockResolvedValue({})
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('renders the login form with navigation link', async () => {
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/auth/login.vue')),
+    )
+
+    const html = page.html()
+    expect(html).toContain('Login')
+    expect(html).toContain('Email')
+    expect(html).toContain("Don't have an account? Sign up")
+  })
+
+  it('submits credentials and redirects to quests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({})
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/auth/login.vue')),
+    )
+
+    page.vm.email = 'user@example.com'
+    page.vm.password = 'super-secret'
+    page.vm.valid = true
+
+    await page.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/login', {
+      method: 'POST',
+      body: {
+        email: 'user@example.com',
+        password: 'super-secret',
+      },
+    })
+    expect(refreshSessionMock).toHaveBeenCalled()
+    expect(routerPushMock).toHaveBeenCalledWith('/quests')
+  })
+})
+
+afterAll(() => {
+  restoreUserSession()
+  restoreUseRouter()
+  vi.unstubAllGlobals()
+})

--- a/apps/nuxt/tests/pages/auth/signup.test.ts
+++ b/apps/nuxt/tests/pages/auth/signup.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { defineAsyncComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const routerPushMock = vi.fn()
+const useRouterMock = vi.fn()
+
+const restoreUseRouter = mockNuxtImport('useRouter', () => useRouterMock)
+
+describe('Auth signup page', () => {
+  beforeEach(() => {
+    routerPushMock.mockReset()
+    useRouterMock.mockReset()
+    useRouterMock.mockReturnValue({ push: routerPushMock })
+
+    const fetchMock = vi.fn().mockResolvedValue({})
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('shows inputs for account creation and login link', async () => {
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/auth/signup.vue')),
+    )
+
+    const html = page.html()
+    expect(html).toContain('Sign Up')
+    expect(html).toContain('Name')
+    expect(html).toContain('Already have an account? Log in')
+  })
+
+  it('submits the signup form and redirects to quests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({})
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/auth/signup.vue')),
+    )
+
+    page.vm.name = 'Ada Lovelace'
+    page.vm.email = 'ada@example.com'
+    page.vm.password = 'engines123'
+    page.vm.valid = true
+
+    await page.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/signup', {
+      method: 'POST',
+      body: {
+        email: 'ada@example.com',
+        name: 'Ada Lovelace',
+        password: 'engines123',
+      },
+    })
+    expect(useRouterMock).toHaveBeenCalled()
+    expect(routerPushMock).toHaveBeenCalledWith('/quests')
+  })
+
+  it('shows the error returned from the server', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('Email already used'))
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/auth/signup.vue')),
+    )
+
+    page.vm.name = 'Existing User'
+    page.vm.email = 'taken@example.com'
+    page.vm.password = 'password'
+    page.vm.valid = true
+
+    await page.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(page.html()).toContain('Email already used')
+  })
+})
+
+afterAll(() => {
+  restoreUseRouter()
+  vi.unstubAllGlobals()
+})

--- a/apps/nuxt/tests/pages/quests/id.test.ts
+++ b/apps/nuxt/tests/pages/quests/id.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { defineAsyncComponent, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const useQuestMock = vi.fn()
+const refreshMock = vi.fn()
+const useRouteMock = vi.fn()
+const intervalPauseMock = vi.fn()
+const intervalResumeMock = vi.fn()
+const useIntervalFnMock = vi.fn(() => ({ pause: intervalPauseMock, resume: intervalResumeMock }))
+
+vi.mock('~/composables/useQuest', () => ({
+  useQuest: useQuestMock,
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useIntervalFn: useIntervalFnMock,
+}))
+
+const restoreUseRoute = mockNuxtImport('useRoute', () => useRouteMock)
+
+describe('Quests detail page', () => {
+  beforeEach(() => {
+    useQuestMock.mockReset()
+    refreshMock.mockReset()
+    useRouteMock.mockReset()
+    intervalPauseMock.mockReset()
+    intervalResumeMock.mockReset()
+    useIntervalFnMock.mockClear()
+
+    useRouteMock.mockReturnValue({ params: { id: 'quest-123' } })
+
+    const fetchMock = vi.fn().mockResolvedValue({})
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('renders quest information and tasks when data is present', async () => {
+    useQuestMock.mockResolvedValue({
+      data: ref({
+        id: 'quest-123',
+        title: 'Heroic Deeds',
+        description: 'Save the realm',
+        status: 'in_progress',
+        goal: 'Become a legend',
+        context: 'Urgent matters',
+        constraints: 'No time to waste',
+        owner: { name: 'Aria' },
+        tasks: [
+          { id: 'task-1', title: 'Gather allies', status: 'pending', details: 'Recruit support' },
+        ],
+      }),
+      refresh: refreshMock,
+      pending: ref(false),
+    })
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/[id].vue')),
+    )
+    await flushPromises()
+
+    const html = page.html()
+    expect(useQuestMock).toHaveBeenCalledWith('quest-123')
+    expect(html).toContain('Heroic Deeds')
+    expect(html).toContain('Save the realm')
+    expect(html).toContain('Gather allies')
+    expect(html).toContain('Aria')
+  })
+
+  it('marks the quest as completed when the action is triggered', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({})
+    vi.stubGlobal('$fetch', fetchMock)
+
+    useQuestMock.mockResolvedValue({
+      data: ref({
+        id: 'quest-999',
+        title: 'Final Challenge',
+        description: 'Face the boss',
+        status: 'in_progress',
+        goal: null,
+        context: null,
+        constraints: null,
+        owner: { name: 'Hero' },
+        tasks: [],
+      }),
+      refresh: refreshMock,
+      pending: ref(false),
+    })
+
+    useRouteMock.mockReturnValue({ params: { id: 'quest-999' } })
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/[id].vue')),
+    )
+    await flushPromises()
+
+    const completeButton = page.findAll('button').find((btn) => btn.text().includes('Mark as Completed'))
+    expect(completeButton).toBeDefined()
+    await completeButton!.trigger('click')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/quests/quest-999', {
+      method: 'PATCH',
+      body: { status: 'completed' },
+    })
+    expect(refreshMock).toHaveBeenCalled()
+  })
+
+  it('shows an error alert when the quest is missing', async () => {
+    useQuestMock.mockResolvedValue({
+      data: ref(null),
+      refresh: refreshMock,
+      pending: ref(false),
+    })
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/[id].vue')),
+    )
+    await flushPromises()
+
+    expect(page.html()).toContain('Quest Not Found')
+  })
+})
+
+afterAll(() => {
+  restoreUseRoute()
+  vi.unstubAllGlobals()
+})

--- a/apps/nuxt/tests/pages/quests/index.test.ts
+++ b/apps/nuxt/tests/pages/quests/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineAsyncComponent, ref } from 'vue'
+
+const useQuestsMock = vi.fn()
+
+vi.mock('~/composables/useQuest', () => ({
+  useQuests: useQuestsMock,
+}))
+
+describe('Quests index page', () => {
+  beforeEach(() => {
+    useQuestsMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('renders quests returned from the composable', async () => {
+    useQuestsMock.mockResolvedValue({
+      data: ref([
+        {
+          id: 'quest-1',
+          title: 'Quest One',
+          description: 'First quest description',
+          goal: 'Finish the journey',
+        },
+      ]),
+    })
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/index.vue')),
+    )
+
+    expect(useQuestsMock).toHaveBeenCalled()
+    const html = page.html()
+    expect(html).toContain('Quest One')
+    expect(html).toContain('First quest description')
+    expect(html).toContain('Finish the journey')
+  })
+
+  it('always shows actions to create a quest', async () => {
+    useQuestsMock.mockResolvedValue({
+      data: ref([]),
+    })
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/index.vue')),
+    )
+
+    const html = page.html()
+    expect(html).toContain('Create Quest')
+    expect(html).toContain('fab')
+  })
+})

--- a/apps/nuxt/tests/pages/quests/new.test.ts
+++ b/apps/nuxt/tests/pages/quests/new.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineAsyncComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const routerPushMock = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}))
+
+describe('Quests new page', () => {
+  beforeEach(() => {
+    routerPushMock.mockReset()
+    const fetchMock = vi.fn().mockResolvedValue({ success: true, quest: { id: 'quest-42' } })
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('renders fields for creating a quest', async () => {
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/new.vue')),
+    )
+
+    const html = page.html()
+    expect(html).toContain('Create a New Quest')
+    expect(html).toContain('Title')
+    expect(html).toContain('Description')
+    expect(html).toContain('Back to Quests')
+  })
+
+  it('posts the form and navigates to the created quest', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ success: true, quest: { id: 'quest-77' } })
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/new.vue')),
+    )
+
+    page.vm.title = 'New Quest'
+    page.vm.description = 'Embark on a journey'
+    page.vm.goal = 'Win'
+    page.vm.context = 'Context details'
+    page.vm.constraints = 'Constraints info'
+    page.vm.valid = true
+
+    await page.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/quests', {
+      method: 'POST',
+      body: {
+        title: 'New Quest',
+        description: 'Embark on a journey',
+        goal: 'Win',
+        context: 'Context details',
+        constraints: 'Constraints info',
+      },
+    })
+    expect(routerPushMock).toHaveBeenCalledWith('/quests/quest-77')
+  })
+
+  it('surfaces errors returned by the API', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('Server failure'))
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const page = await mountSuspended(
+      defineAsyncComponent(() => import('~/pages/quests/new.vue')),
+    )
+
+    page.vm.title = 'Bad Quest'
+    page.vm.description = 'Fails to save'
+    page.vm.valid = true
+
+    await page.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(page.html()).toContain('Server failure')
+  })
+})


### PR DESCRIPTION
## Summary
- add login page tests to confirm the form renders and submission refreshes the session before redirecting
- add signup page tests verifying successful creation redirects to quests and surfaces server errors
- add quest creation and detail page tests that assert rendering, navigation, and completion behaviours

## Testing
- pnpm --filter nuxt test -- --runTestsByPath apps/nuxt/tests/pages/auth/login.test.ts *(fails: Vitest cannot resolve the generated `.nuxt/tsconfig.json` without running `nuxt prepare` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bd7aaf3483289ef8892261633dbe